### PR TITLE
Add support to the Generic Access Token from Bitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $link = new Link;
 $link->setLongUrl('http://www.google.com');
 
 $bitlyProvider = new BitlyProvider(
-    new OAuthClient('username', 'password'),
+    new OAuthClient('username', 'password'), // or new GenericAccessTokenAuthenticator('generic_access_token')
     array('connect_timeout' => 1, 'timeout' => 1)
 );
 
@@ -101,7 +101,7 @@ $link = new Link;
 $link->setLongUrl('http://www.google.com');
 
 $bitlyProvider = new BitlyProvider(
-    new OAuthClient('username', 'password'),
+    new OAuthClient('username', 'password'), // or new GenericAccessTokenAuthenticator('generic_access_token')
     array('connect_timeout' => 1, 'timeout' => 1)
 );
 

--- a/src/Mremi/UrlShortener/Provider/Bitly/GenericAccessTokenAuthenticator.php
+++ b/src/Mremi/UrlShortener/Provider/Bitly/GenericAccessTokenAuthenticator.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Mremi\UrlShortener library.
+ *
+ * (c) Rémi Marseille <marseille.remi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mremi\UrlShortener\Provider\Bitly;
+
+/**
+ * GenericAccessTokenAuthenticator class
+ *
+ * @author Marcus Sá <marcusesa@gmail.com>
+ */
+class GenericAccessTokenAuthenticator implements AuthenticationInterface
+{
+    /**
+     * @var string
+     */
+    private $genericAccessToken;
+
+    /**
+     * Constructor
+     *
+     * @param string $genericAccessToken generic access token is a immutable token provided by Bitly
+     */
+    public function __construct($genericAccessToken)
+    {
+        $this->genericAccessToken = $genericAccessToken;
+    }
+
+    /**
+     * Return the Generic Access Token
+     *
+     * @return string
+     */
+    public function getAccessToken()
+    {
+        return $this->genericAccessToken;
+    }
+}

--- a/tests/Mremi/UrlShortener/Tests/Provider/Bitly/GenericAccessTokenAuthenticatorTest.php
+++ b/tests/Mremi/UrlShortener/Tests/Provider/Bitly/GenericAccessTokenAuthenticatorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Mremi\UrlShortener library.
+ *
+ * (c) Rémi Marseille <marseille.remi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mremi\UrlShortener\Tests\Provider\Bitly;
+
+use Mremi\UrlShortener\Provider\Bitly\GenericAccessTokenAuthenticator;
+
+/**
+ * Tests GenericAccessTokenAuthenticator class
+ *
+ * @author Marcus Sá <marcusesa@gmail.com>
+ */
+class GenericAccessTokenAuthenticatorTest extends \PHPUnit_Framework_TestCase
+{
+    const GENERIC_ACCESS_TOKEN = '9a2j4kal4701mk2enk15lmi2';
+
+    /**
+     * Test if GenericAccessTokenAuthenticator implements AuthenticationInterface
+     */
+    public function testGenericAccessTokenShouldImplementsAuthenticationInterface()
+    {
+        $genericAccessTokenAuthenticator = new GenericAccessTokenAuthenticator(self::GENERIC_ACCESS_TOKEN);
+
+        $this->assertInstanceOf(
+            'Mremi\UrlShortener\Provider\Bitly\AuthenticationInterface',
+            $genericAccessTokenAuthenticator
+        );
+    }
+
+    /**
+     * Test if getAccessToken method return the generic access token provided
+     */
+    public function testGetAccessTokenShouldReturnGenericAccessToken()
+    {
+        $genericAccessTokenAuthenticator = new GenericAccessTokenAuthenticator(self::GENERIC_ACCESS_TOKEN);
+
+        $this->assertEquals(self::GENERIC_ACCESS_TOKEN, $genericAccessTokenAuthenticator->getAccessToken());
+    }
+}


### PR DESCRIPTION
## Add support to the Generic Access Token from Bitly

Adding support to the Generic Access Token from Bitly, generic access token is a immutable token provided by Bitly.

> Many of Bitly's API methods require an OAuth access_token for authentication. For testing purposes, or cases where you are only making API requests on behalf of your own account, you can generate a generic access_token. https://bitly.com/a/oauth_apps
### Changes:
- Add GenericAccessTokenAuthenticator
- Add GenericAccessTokenAuthenticatorTest
