### PR TITLE
Improve travis configuration and support of php 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,23 @@
 language: php
 
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 php:
   - 5.3
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
-before_script: composer install --dev --prefer-source
+before_install:
+  - composer self-update
+
+install: composer install --dev --prefer-dist --no-interaction
+
+script:
+  - make ci

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,13 @@
         "symfony/phpunit-bridge": "~2.7|~3.0"
     },
     "autoload": {
-        "psr-0": { "Mremi\\UrlShortener": "src" }
+        "psr-4": {
+            "Mremi\\UrlShortener\\": "src/Mremi/UrlShortener"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Mremi\\UrlShortener\\Tests\\": "tests/Mremi/UrlShortener/Tests"
+        }
     }
 }


### PR DESCRIPTION
- testing PHP 7.0
- switch to the faster container-based infrastructure on Travis
- persist the composer cache between builds
- switch to the PSR-4 autoloading (PSR-0 is deprecated)
- use autoload-dev to register the test autoloading
