### PR TITLE
Bumped minimum required Symfony Console version to ^2.7 and allowed Symfony ^3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0 (2017-03-29)
+
+* Bumped minimum required Symfony Console version to ^2.7 and allowed Symfony ^3.1
+
 ## 2.0.0 (2017-01-27)
 
 * Bumped minimum required PHP version to 5.5

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,14 @@
         }
     ],
     "require": {
-        "php": "^5.5|^7.0",
+        "php": "^5.5 || ^7.0",
         "guzzlehttp/guzzle": "^6.0",
-        "symfony/console": "~2.5"
+        "symfony/console": "^2.7 || ^3.1"
     },
     "require-dev": {
-        "fabpot/php-cs-fixer": "~0.1|~1.0",
+        "fabpot/php-cs-fixer": "~0.1 || ~1.0",
         "phpunit/phpunit": "~4.8",
-        "symfony/phpunit-bridge": "~2.7|~3.0"
+        "symfony/phpunit-bridge": "~2.7 || ~3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
At this time we have a dependency on symfony/console ^2.5 and this is a blocker on projects with Symfony 3.x.