### PR TITLE
Add support for PHP 8, Guzzle 7, Symfony 6, and PHP CS Fixer 2.19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .php_cs
 .php_cs.cache
+.phpunit.result.cache
 composer.lock
 phpunit.xml
 vendor

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -12,7 +12,7 @@ EOF;
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__);
 
-$config = PhpCsFixer\Config::create()
+$config = (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@Symfony' => true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ jobs:
     - php: 7.2
     - php: 7.3
     - php: 7.4
+    - php: 8.0
+    - php: nightly
+  allow_failures:
+    - php: nightly
 
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
+## 2.3.0 (2020-03-23)
+
+* Bump minimum required PHP version to 5.6
+* Add support for PHP 7.2+
+* Drop support for HHVM (composer/composer#8127)
+* Update [Bitly API](https://bitly.is/v4ing) version to 4
+* Update [phpunit/phpunit](https://packagist.org/packages/phpunit/phpunit) version to ^5.7
+* Update [symfony/phpunit-bridge](https://packagist.org/packages/symfony/phpunit-bridge) version to ^5.0
+* Replace [fabpot/php-cs-fixer](https://packagist.org/packages/fabpot/php-cs-fixer) with [friendsofphp/php-cs-fixer v2.16](https://packagist.org/packages/friendsofphp/php-cs-fixer) version ^2.16
+
 ## 2.2.1 (2018-10-09)
+
 * Update [symfony/console](https://github.com/symfony/console) version to ^4.1 (See [#14](https://github.com/mremi/UrlShortener/issues/14))
 
 ## 2.2.0 (2018-09-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add support for PHP 8+
 * Add support for Guzzle 7+
 * Add support for Symfony 6+
+* Modernize tests
 
 ## 2.3.0 (2020-03-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.4.0 (TBD)
+
+* Add support for PHP 8+
+* Add support for Guzzle 7+
+* Add support for Symfony 6+
+
 ## 2.3.0 (2020-03-23)
 
 * Bump minimum required PHP version to 5.6

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ install:
 	composer install
 
 test:
-	@if [ ! -f vendor/bin/phpunit ]; then make install; fi
-	vendor/bin/phpunit
+	@if [ ! -f vendor/bin/simple-phpunit ]; then make install; fi
+	SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT=1 vendor/bin/simple-phpunit
 
 update:
 	composer update

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This library allows you to shorten a URL, reverse is also possible.
 
 [![SensioLabsInsight](https://insight.sensiolabs.com/projects/c4e06c9d-547c-47bb-8abb-fccc68b7df7a/big.png)](https://insight.sensiolabs.com/projects/c4e06c9d-547c-47bb-8abb-fccc68b7df7a)
 
-[![Build Status](https://api.travis-ci.org/mremi/UrlShortener.png?branch=master)](https://travis-ci.org/mremi/UrlShortener)
+[![Build Status](https://api.travis-ci.com/mremi/UrlShortener.png?branch=master)](https://travis-ci.org/mremi/UrlShortener)
 [![Total Downloads](https://poser.pugx.org/mremi/url-shortener/downloads.png)](https://packagist.org/packages/mremi/url-shortener)
 [![Latest Stable Version](https://poser.pugx.org/mremi/url-shortener/v/stable.png)](https://packagist.org/packages/mremi/url-shortener)
 [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/mremi/UrlShortener/badges/quality-score.png?s=34c4ba6b0cd272673fa121c32a63e1ce668b9b2a)](https://scrutinizer-ci.com/g/mremi/UrlShortener/)

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "mremi/url-shortener",
     "type": "library",
-    "description": "A PHP5 library using API to shorten/expand URL",
-    "keywords": ["url", "shortener", "api"],
+    "description": "A PHP5/PHP7/PHP8 library using API to shorten/expand URL",
+    "keywords": [ "url", "shortener", "api" ],
     "homepage": "https://github.com/mremi/UrlShortener",
     "license": "MIT",
     "authors": [
@@ -12,9 +12,9 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
-        "guzzlehttp/guzzle": "^6.0",
-        "symfony/console": "^3.1 || ^4.1 || ^v5.0"
+        "php": "^5.6 || ^7.0 || ^8.0",
+        "guzzlehttp/guzzle": "^6.0 || ^7.0",
+        "symfony/console": "^3.1 || ^4.1 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",
-        "phpunit/phpunit": "~5.7 || ~6.5 || ~7.5",
-        "symfony/phpunit-bridge": "^5.0"
+        "symfony/phpunit-bridge": "^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.3-dev"
+            "dev-master": "2.4-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/console": "^3.1 || ^4.1 || ^5.0 || ^6.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.16",
+        "friendsofphp/php-cs-fixer": "^2.19",
         "symfony/phpunit-bridge": "^5.0 || ^6.0"
     },
     "autoload": {

--- a/tests/Mremi/UrlShortener/Tests/Provider/Baidu/BaiduProviderTest.php
+++ b/tests/Mremi/UrlShortener/Tests/Provider/Baidu/BaiduProviderTest.php
@@ -12,6 +12,7 @@
 namespace Mremi\UrlShortener\Tests\Provider\Baidu;
 
 use GuzzleHttp\ClientInterface;
+use Mremi\UrlShortener\Exception\InvalidApiResponseException;
 use Mremi\UrlShortener\Model\LinkInterface;
 use Mremi\UrlShortener\Provider\Baidu\BaiduProvider;
 use PHPUnit\Framework\TestCase;
@@ -50,12 +51,12 @@ class BaiduProviderTest extends TestCase
 
     /**
      * Tests the shorten method throws exception if Baidu returns a string.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Baidu response is probably mal-formed because cannot be json-decoded.
      */
     public function testShortenThrowsExceptionIfResponseApiIsString()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Baidu response is probably mal-formed because cannot be json-decoded.');
+
         $this->mockClient($this->getMockResponseAsString(), 'post');
 
         $this->provider->shorten($this->getBaseMockLink());
@@ -63,12 +64,12 @@ class BaiduProviderTest extends TestCase
 
     /**
      * Tests the shorten method throws exception if Baidu returns an error response.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Baidu returned code error message "-1: long url is not valid
      */
     public function testShortenThrowsExceptionIfApiResponseIsError()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Baidu returned code error message "-1: long url is not valid');
+
         $this->mockClient($this->getMockResponseWithError(), 'post');
 
         $this->provider->shorten($this->getBaseMockLink());
@@ -76,12 +77,12 @@ class BaiduProviderTest extends TestCase
 
     /**
      * Tests the shorten method throws exception if Baidu returns a response with no short url.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Baidu returned code error message "-1: unsafe url
      */
     public function testShortenThrowsExceptionIfApiResponseHasNoShortUrl()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Baidu returned code error message "-1: unsafe url');
+
         $this->mockClient($this->getMockResponseWithNoShortUrl(), 'post');
 
         $this->provider->shorten($this->getBaseMockLink());
@@ -127,12 +128,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Baidu returns a string.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Baidu response is probably mal-formed because cannot be json-decoded.
      */
     public function testExpandThrowsExceptionIfResponseApiIsString()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Baidu response is probably mal-formed because cannot be json-decoded.');
+
         $this->mockClient($this->getMockResponseAsString(), 'post');
 
         $this->provider->expand($this->getBaseMockLink());
@@ -140,12 +141,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Baidu returns an error response.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Baidu returned code error message "-1: long url is not valid
      */
     public function testExpandThrowsExceptionIfApiResponseIsError()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Baidu returned code error message "-1: long url is not valid');
+
         $this->mockClient($this->getMockResponseWithError(), 'post');
 
         $this->provider->expand($this->getBaseMockLink());
@@ -153,12 +154,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Baidu returns a response with no longUrl.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Baidu returned code error message "-2: short url dose not exist
      */
     public function testExpandThrowsExceptionIfApiResponseHasNoLongUrl()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Baidu returned code error message "-2: short url dose not exist');
+
         $this->mockClient($this->getMockResponseWithNoLongUrl(), 'post');
 
         $this->provider->expand($this->getBaseMockLink());
@@ -166,12 +167,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Baidu returns a response with no status.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Property "Code" does not exist within Baidu response.
      */
     public function testExpandThrowsExceptionIfApiResponseHasNoStatus()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Property "Code" does not exist within Baidu response.');
+
         $response = $this->getBaseMockResponse();
 
         $apiRawResponse = <<<'JSON'

--- a/tests/Mremi/UrlShortener/Tests/Provider/Bitly/BitlyProviderTest.php
+++ b/tests/Mremi/UrlShortener/Tests/Provider/Bitly/BitlyProviderTest.php
@@ -12,6 +12,7 @@
 namespace Mremi\UrlShortener\Tests\Provider\Bitly;
 
 use GuzzleHttp\ClientInterface;
+use Mremi\UrlShortener\Exception\InvalidApiResponseException;
 use Mremi\UrlShortener\Model\LinkInterface;
 use Mremi\UrlShortener\Provider\Bitly\AuthenticationInterface;
 use Mremi\UrlShortener\Provider\Bitly\BitlyProvider;
@@ -33,12 +34,12 @@ class BitlyProviderTest extends TestCase
 
     /**
      * Tests the shorten method throws exception if Bit.ly returns a string.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Bit.ly response is probably mal-formed because cannot be json-decoded.
      */
     public function testShortenThrowsExceptionIfApiResponseIsString()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Bit.ly response is probably mal-formed because cannot be json-decoded.');
+
         $this->mockClient($this->getMockResponseAsString());
 
         $this->provider->shorten($this->getBaseMockLink());
@@ -46,12 +47,12 @@ class BitlyProviderTest extends TestCase
 
     /**
      * Tests the shorten method throws exception if Bit.ly returns an invalid status code.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Bit.ly returned status code "404" with message "NOT_FOUND"
      */
     public function testShortenThrowsExceptionIfApiResponseHasInvalidStatusCode()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Bit.ly returned status code "404" with message "NOT_FOUND"');
+
         $this->mockClient($this->getMockResponseWithInvalidStatusCode());
 
         $this->provider->shorten($this->getBaseMockLink());
@@ -107,12 +108,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Bit.ly returns a string.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Bit.ly response is probably mal-formed because cannot be json-decoded.
      */
     public function testExpandThrowsExceptionIfApiResponseIsString()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Bit.ly response is probably mal-formed because cannot be json-decoded.');
+
         $this->mockClient($this->getMockResponseAsString());
 
         $this->provider->expand($this->getBaseMockLink());
@@ -120,12 +121,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Bit.ly returns an invalid status code.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Bit.ly returned status code "404" with message "NOT_FOUND"
      */
     public function testExpandThrowsExceptionIfApiResponseHasInvalidStatusCode()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Bit.ly returned status code "404" with message "NOT_FOUND"');
+
         $this->mockClient($this->getMockResponseWithInvalidStatusCode());
 
         $this->provider->expand($this->getBaseMockLink());

--- a/tests/Mremi/UrlShortener/Tests/Provider/ChainProviderTest.php
+++ b/tests/Mremi/UrlShortener/Tests/Provider/ChainProviderTest.php
@@ -18,6 +18,7 @@ use Mremi\UrlShortener\Provider\Google\GoogleProvider;
 use Mremi\UrlShortener\Provider\Sina\SinaProvider;
 use Mremi\UrlShortener\Provider\Wechat\WechatProvider;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 /**
  * Tests ChainProvider class.
@@ -28,12 +29,12 @@ class ChainProviderTest extends TestCase
 {
     /**
      * Tests that an unknown provider throws an exception.
-     *
-     * @expectedException        \RuntimeException
-     * @expectedExceptionMessage Unable to retrieve the provider named: "foo"
      */
     public function testUnknownProvider()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to retrieve the provider named: "foo"');
+
         $chainProvider = new ChainProvider();
         $chainProvider->getProvider('foo');
     }

--- a/tests/Mremi/UrlShortener/Tests/Provider/Google/GoogleProviderTest.php
+++ b/tests/Mremi/UrlShortener/Tests/Provider/Google/GoogleProviderTest.php
@@ -12,6 +12,7 @@
 namespace Mremi\UrlShortener\Tests\Provider\Google;
 
 use GuzzleHttp\ClientInterface;
+use Mremi\UrlShortener\Exception\InvalidApiResponseException;
 use Mremi\UrlShortener\Model\LinkInterface;
 use Mremi\UrlShortener\Provider\Google\GoogleProvider;
 use PHPUnit\Framework\TestCase;
@@ -88,12 +89,12 @@ class GoogleProviderTest extends TestCase
 
     /**
      * Tests the shorten method throws exception if Google returns a string.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Google response is probably mal-formed because cannot be json-decoded.
      */
     public function testShortenThrowsExceptionIfResponseApiIsString()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Google response is probably mal-formed because cannot be json-decoded.');
+
         $this->mockClient($this->getMockResponseAsString(), 'post');
 
         $this->provider->shorten($this->getBaseMockLink());
@@ -101,12 +102,12 @@ class GoogleProviderTest extends TestCase
 
     /**
      * Tests the shorten method throws exception if Google returns an error response.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Google returned status code "400" with message "Required"
      */
     public function testShortenThrowsExceptionIfApiResponseIsError()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Google returned status code "400" with message "Required"');
+
         $this->mockClient($this->getMockResponseWithError(), 'post');
 
         $this->provider->shorten($this->getBaseMockLink());
@@ -114,12 +115,12 @@ class GoogleProviderTest extends TestCase
 
     /**
      * Tests the shorten method throws exception if Google returns a response with no id.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Property "id" does not exist within Google response.
      */
     public function testShortenThrowsExceptionIfApiResponseHasNoId()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Property "id" does not exist within Google response.');
+
         $this->mockClient($this->getMockResponseWithNoId(), 'post');
 
         $this->provider->shorten($this->getBaseMockLink());
@@ -127,12 +128,12 @@ class GoogleProviderTest extends TestCase
 
     /**
      * Tests the shorten method throws exception if Google returns a response with no longUrl.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Property "longUrl" does not exist within Google response.
      */
     public function testShortenThrowsExceptionIfApiResponseHasNoLongUrl()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Property "longUrl" does not exist within Google response.');
+
         $this->mockClient($this->getMockResponseWithNoLongUrl(), 'post');
 
         $this->provider->shorten($this->getBaseMockLink());
@@ -177,12 +178,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Google returns a string.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Google response is probably mal-formed because cannot be json-decoded.
      */
     public function testExpandThrowsExceptionIfResponseApiIsString()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Google response is probably mal-formed because cannot be json-decoded.');
+
         $this->mockClient($this->getMockResponseAsString(), 'get');
 
         $this->provider->expand($this->getBaseMockLink());
@@ -190,12 +191,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Google returns an error response.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Google returned status code "400" with message "Required"
      */
     public function testExpandThrowsExceptionIfApiResponseIsError()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Google returned status code "400" with message "Required"');
+
         $this->mockClient($this->getMockResponseWithError(), 'get');
 
         $this->provider->expand($this->getBaseMockLink());
@@ -203,12 +204,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Google returns a response with no id.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Property "id" does not exist within Google response.
      */
     public function testExpandThrowsExceptionIfApiResponseHasNoId()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Property "id" does not exist within Google response.');
+
         $this->mockClient($this->getMockResponseWithNoId(), 'get');
 
         $this->provider->expand($this->getBaseMockLink());
@@ -216,12 +217,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Google returns a response with no longUrl.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Property "longUrl" does not exist within Google response.
      */
     public function testExpandThrowsExceptionIfApiResponseHasNoLongUrl()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Property "longUrl" does not exist within Google response.');
+
         $this->mockClient($this->getMockResponseWithNoLongUrl(), 'get');
 
         $this->provider->expand($this->getBaseMockLink());
@@ -229,12 +230,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Google returns a response with no status.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Property "status" does not exist within Google response.
      */
     public function testExpandThrowsExceptionIfApiResponseHasNoStatus()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Property "status" does not exist within Google response.');
+
         $response = $this->getBaseMockResponse();
 
         $apiRawResponse = <<<'JSON'
@@ -263,12 +264,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Google returns an invalid status code.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Google returned status code "KO".
      */
     public function testExpandThrowsExceptionIfApiResponseHasInvalidStatusCode()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Google returned status code "KO".');
+
         $response = $this->getBaseMockResponse();
 
         $apiRawResponse = <<<'JSON'

--- a/tests/Mremi/UrlShortener/Tests/Provider/Sina/SinaProviderTest.php
+++ b/tests/Mremi/UrlShortener/Tests/Provider/Sina/SinaProviderTest.php
@@ -12,6 +12,7 @@
 namespace Mremi\UrlShortener\Tests\Provider\Sina;
 
 use GuzzleHttp\ClientInterface;
+use Mremi\UrlShortener\Exception\InvalidApiResponseException;
 use Mremi\UrlShortener\Model\LinkInterface;
 use Mremi\UrlShortener\Provider\Sina\SinaProvider;
 use PHPUnit\Framework\TestCase;
@@ -50,12 +51,12 @@ class SinaProviderTest extends TestCase
 
     /**
      * Tests the shorten method throws exception if Sina returns a string.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Sina response is probably mal-formed because cannot be json-decoded.
      */
     public function testShortenThrowsExceptionIfResponseApiIsString()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Sina response is probably mal-formed because cannot be json-decoded.');
+
         $this->mockClient($this->getMockResponseAsString(), 'get');
 
         $this->provider->shorten($this->getBaseMockLink());
@@ -63,12 +64,12 @@ class SinaProviderTest extends TestCase
 
     /**
      * Tests the shorten method throws exception if Sina returns an error response.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Sina returned status code "10006" with message "source paramter(appkey) is missing
      */
     public function testShortenThrowsExceptionIfApiResponseIsError()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Sina returned status code "10006" with message "source paramter(appkey) is missing');
+
         $this->mockClient($this->getMockResponseWithError(), 'get');
 
         $this->provider->shorten($this->getBaseMockLink());
@@ -76,12 +77,12 @@ class SinaProviderTest extends TestCase
 
     /**
      * Tests the shorten method throws exception if Sina returns a response with no id.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Sina returned status code "10006" with message "source paramter(appkey) is missing
      */
     public function testShortenThrowsExceptionIfApiResponseHasNoId()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Sina returned status code "10006" with message "source paramter(appkey) is missing');
+
         $this->mockClient($this->getMockResponseWithNoId(), 'get');
 
         $this->provider->shorten($this->getBaseMockLink());
@@ -89,12 +90,12 @@ class SinaProviderTest extends TestCase
 
     /**
      * Tests the shorten method throws exception if Sina returns a response with no longUrl.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Property "longUrl" does not exist within Sina response.
      */
     public function testShortenThrowsExceptionIfApiResponseHasNoLongUrl()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Property "longUrl" does not exist within Sina response.');
+
         $this->mockClient($this->getMockResponseWithNoLongUrl(), 'get');
 
         $this->provider->shorten($this->getBaseMockLink());
@@ -146,12 +147,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Sina returns a string.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Sina response is probably mal-formed because cannot be json-decoded.
      */
     public function testExpandThrowsExceptionIfResponseApiIsString()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Sina response is probably mal-formed because cannot be json-decoded.');
+
         $this->mockClient($this->getMockResponseAsString(), 'get');
 
         $this->provider->expand($this->getBaseMockLink());
@@ -159,12 +160,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Sina returns an error response.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Sina returned status code "10006" with message "source paramter(appkey) is missing"
      */
     public function testExpandThrowsExceptionIfApiResponseIsError()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Sina returned status code "10006" with message "source paramter(appkey) is missing"');
+
         $this->mockClient($this->getMockResponseWithError(), 'get');
 
         $this->provider->expand($this->getBaseMockLink());
@@ -172,12 +173,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Sina returns a response with no id.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Sina returned status code "10006" with message "source paramter(appkey) is missing"
      */
     public function testExpandThrowsExceptionIfApiResponseHasNoId()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Sina returned status code "10006" with message "source paramter(appkey) is missing"');
+
         $this->mockClient($this->getMockResponseWithNoId(), 'get');
 
         $this->provider->expand($this->getBaseMockLink());
@@ -185,12 +186,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Sina returns a response with no longUrl.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Property "longUrl" does not exist within Sina response.
      */
     public function testExpandThrowsExceptionIfApiResponseHasNoLongUrl()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Property "longUrl" does not exist within Sina response.');
+
         $this->mockClient($this->getMockResponseWithNoLongUrl(), 'get');
 
         $this->provider->expand($this->getBaseMockLink());
@@ -198,12 +199,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Sina returns an invalid status code.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Sina returned status code "21506" with message "Error: Parameter value is not valid!
      */
     public function testExpandThrowsExceptionIfApiResponseHasInvalidStatusCode()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Sina returned status code "21506" with message "Error: Parameter value is not valid!');
+
         $response = $this->getBaseMockResponse();
 
         $apiRawResponse = <<<'JSON'

--- a/tests/Mremi/UrlShortener/Tests/Provider/Wechat/WechatProviderTest.php
+++ b/tests/Mremi/UrlShortener/Tests/Provider/Wechat/WechatProviderTest.php
@@ -12,6 +12,7 @@
 namespace Mremi\UrlShortener\Tests\Provider\Wechat;
 
 use GuzzleHttp\ClientInterface;
+use Mremi\UrlShortener\Exception\InvalidApiResponseException;
 use Mremi\UrlShortener\Model\LinkInterface;
 use Mremi\UrlShortener\Provider\Bitly\AuthenticationInterface;
 use Mremi\UrlShortener\Provider\Wechat\WechatProvider;
@@ -54,12 +55,12 @@ class WechatProviderTest extends TestCase
 
     /**
      * Tests the shorten method throws exception if Wechat returns a string.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Wechat response is probably mal-formed because cannot be json-decoded.
      */
     public function testShortenThrowsExceptionIfApiResponseIsString()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Wechat response is probably mal-formed because cannot be json-decoded.');
+
         $this->mockClient($this->getMockResponseAsString());
 
         $this->provider->shorten($this->getBaseMockLink());
@@ -67,12 +68,12 @@ class WechatProviderTest extends TestCase
 
     /**
      * Tests the shorten method throws exception if Wechat returns a response with no errcode.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Property "errcode" does not exist within Wechat response.
      */
     public function testShortenThrowsExceptionIfApiResponseHasNoErrorCode()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Property "errcode" does not exist within Wechat response.');
+
         $this->mockClient($this->getMockResponseAsInvalidObject());
 
         $this->provider->shorten($this->getBaseMockLink());
@@ -80,12 +81,12 @@ class WechatProviderTest extends TestCase
 
     /**
      * Tests the shorten method throws exception if Wechat returns an invalid status code.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Wechat returned status code "40001" with message "invalid credential, access_token is invalid or not latest hint: [miSs30226vr31!]"
      */
     public function testShortenThrowsExceptionIfApiResponseHasInvalidStatusCode()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Wechat returned status code "40001" with message "invalid credential, access_token is invalid or not latest hint: [miSs30226vr31!]"');
+
         $this->mockClient($this->getMockResponseWithInvalidStatusCode());
 
         $this->provider->shorten($this->getBaseMockLink());
@@ -130,12 +131,12 @@ JSON;
 
     /**
      * Tests the expand method throws exception if Wechat returns a string.
-     *
-     * @expectedException        \Mremi\UrlShortener\Exception\InvalidApiResponseException
-     * @expectedExceptionMessage Wechat does not support expand url yet.
      */
     public function testExpandThrowsExceptionIfApiResponseIsString()
     {
+        $this->expectException(InvalidApiResponseException::class);
+        $this->expectExceptionMessage('Wechat does not support expand url yet.');
+
         //$this->mockClient($this->getMockResponseAsString());
 
         $this->provider->expand($this->getBaseMockLink());


### PR DESCRIPTION
Added:

- Support for PHP 8 (resolves #26)
- Support for guzzlehttp/guzzle 7 (resolves #27)
- Support for symfony/console 6
- Support for symfony/phpunit-bridge 6

Removed:

- Dependency on phpunit/phpunit (provided by symfony/phpunit-bridge)

Changed:

- Replaced usage of `phpunit` binary with `simple-phpunit` for improved compatibility across phpunit versions.
- Replaced `@expectedException` annotations with equivalent methods for improved compatibility across phpunit versions.
- Updated friendsofphp/php-cs-fixer to 2.19 (to support PHP 8 while maintaining support for PHP 5).
- Updated initialization of `PhpCsFixer\Config` object to match requirements for PHP CS Fixer 3.0.
- Renamed `.php_cs.dist` to `.php-cs-fixer.dist.php` to match requirements for PHP CS Fixer 3.0.
- Switched build status badge from travis-ci.org to travis-ci.com.

---

In the meantime, people can use my fork:

```json
"require": {
    "mremi/url-shortener": "^2.4"
},
"repositories": [
    {
        "type": "vcs",
        "url": "https://github.com/mcaskill/UrlShortener"
    }
]
```