### PR TITLE
- fix Bit.ly url handling

### DIFF
--- a/src/Mremi/UrlShortener/Provider/Bitly/OAuthClient.php
+++ b/src/Mremi/UrlShortener/Provider/Bitly/OAuthClient.php
@@ -48,10 +48,10 @@ class OAuthClient implements AuthenticationInterface
     public function getAccessToken()
     {
         $client = new Client([
-            'base_uri' => 'https://api-ssl.bitly.com/oauth/access_token',
+            'base_uri' => 'https://api-ssl.bitly.com/oauth/',
         ]);
 
-        $response = $client->post(null, [
+        $response = $client->post('access_token', [
             'auth' => [
                 $this->username,
                 $this->password,


### PR DESCRIPTION
passing `null` as uri is invalid and causes and exception with guzzle
`URI must be a string or UriInterface`

this is a simple fix